### PR TITLE
Add Github Action to generate Windows build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,57 @@
+# This workflow creates an application distribution zip file and uploads it as an Action artifact.
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: windows-2019
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v2
+        with:
+          version: '5.15.2'
+          host: 'windows'
+          target: 'desktop'
+          arch: 'win64_msvc2019_64'
+
+      - name: Configure and build application
+        run: |
+          call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          qmake -makefile EM1802.pro
+          nmake
+        shell: cmd
+
+      - name: Create distribution
+        run: |
+          set PATH=%Qt5_Dir%\bin;%PATH%
+          call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          md dist
+          copy release\EM1802.exe dist
+          windeployqt.exe dist
+          copy idiot4.hex dist
+        shell: cmd
+
+      - name: Upload artifact (zip file)
+        uses: actions/upload-artifact@v1
+        with:
+          name: EM1802
+          path: ${{ github.workspace }}/dist


### PR DESCRIPTION
This Action as written runs whenever a commit is pushed to the repository.  This behavior can be changed (See Github Actions docs).

Windows Only.
It downloads and installs the Qt framework and builds the executable.  It then uses a Qt Windows deployment script that creates a directory with the executable and all dependencies.  Finally, it creates a build artifact in the form of a zip file containing the deployment directory.

The artifact zip file can then be downloaded once the Action completes from the Actions tab on this repo's Github page.
