### PR TITLE
Fix memory leak in disassembler

### DIFF
--- a/processor.cpp
+++ b/processor.cpp
@@ -19,6 +19,7 @@ Processor::Processor(QWidget *parent, Memory &RAM) :
 
     QFontMetrics fm(font);
     ui->Disassembly->setMinimumWidth(fm.horizontalAdvance(DisassemblyTemplate)+35);
+    ui->Disassembly->setMaximumBlockCount(DisassemblerLines);
 
     ui->CDP1806->setVisible(false);
 


### PR DESCRIPTION
Reproduce by simply running the default flash Q program already
in memory and turning up the speed to the max.

The process memory size grows by about 2MB per second.

Not completely sure that this is the correct fix, but it seems to
work.

See:
https://doc.qt.io/qt-5/qplaintextedit.html#using-qplaintextedit-as-a-display-widget

for a discussion that suggests this fix is the right approach for using
this widget as a log viewer.  I didn't see any way to delete blocks as
lines/paragraphs are appended.